### PR TITLE
Refactor AddCommandParser to support and delete Student fields and mo…

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -4,13 +4,10 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ASSIGNMENT_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDANCE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CLASS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PAYMENT_STATUS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECTS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -24,29 +21,24 @@ import seedu.address.model.person.Person;
 public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
-
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a student to the list of students. "
-            + "Parameters: "
-            + PREFIX_NAME + "NAME "
-            + PREFIX_PHONE + "PHONE "
-            + PREFIX_EMAIL + "EMAIL "
-            + PREFIX_CLASS + "CLASS "
-            + PREFIX_SUBJECTS + "SUBJECTS (CSV) "
-            + PREFIX_EMERGENCY_CONTACT + "EMERGENCY_CONTACT "
-            + "[" + PREFIX_ATTENDANCE + "ATTENDANCE] "
-            + "[" + PREFIX_PAYMENT_STATUS + "PAYMENT_STATUS] "
-            + "[" + PREFIX_ASSIGNMENT_STATUS + "ASSIGNMENT_STATUS] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "John Doe "
-            + PREFIX_PHONE + "98765432 "
-            + PREFIX_EMAIL + "johnd@example.com "
-            + PREFIX_CLASS + "10A "
-            + PREFIX_SUBJECTS + "Math,Physics,Chemistry "
-            + PREFIX_EMERGENCY_CONTACT + "91234567 "
-            + PREFIX_ATTENDANCE + "Present "
-            + PREFIX_PAYMENT_STATUS + "Paid "
-            + PREFIX_ASSIGNMENT_STATUS + "Completed";
+        + "Parameters: "
+        + PREFIX_NAME + "NAME "
+        + PREFIX_CLASS + "CLASS "
+        + PREFIX_SUBJECTS + "SUBJECT [s/SUBJECT]... "
+        + PREFIX_EMERGENCY_CONTACT + "EMERGENCY_CONTACT "
+        + "[" + PREFIX_ATTENDANCE + "ATTENDANCE] "
+        + "[" + PREFIX_PAYMENT_STATUS + "PAYMENT_STATUS] "
+        + "[" + PREFIX_ASSIGNMENT_STATUS + "ASSIGNMENT_STATUS]...\n"
+        + "Example: " + COMMAND_WORD + " "
+        + PREFIX_NAME + "John Tan "
+        + PREFIX_CLASS + "3B "
+        + PREFIX_SUBJECTS + "Math s/Science "
+        + PREFIX_EMERGENCY_CONTACT + "91234567 "
+        + PREFIX_ATTENDANCE + "Present "
+        + PREFIX_PAYMENT_STATUS + "Paid "
+        + PREFIX_ASSIGNMENT_STATUS + "Completed";
+
 
     public static final String MESSAGE_SUCCESS = "New student added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This student already exists in the student list";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,61 +1,105 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ASSIGNMENT_STATUS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDANCE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CLASS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PAYMENT_STATUS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECTS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
+import seedu.address.model.attendance.AttendanceList;
+import seedu.address.model.attendance.AttendanceStatus;
 import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
+import seedu.address.model.student.Student;
 import seedu.address.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new AddCommand object
+ * Parses input arguments and creates a new AddCommand object.
  */
 public class AddCommandParser implements Parser<AddCommand> {
 
-    /**
-     * Parses the given {@code String} of arguments in the context of the AddCommand
-     * and returns an AddCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
-     */
+    @Override
     public AddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
+                args,
+                PREFIX_NAME, PREFIX_CLASS, PREFIX_SUBJECTS, PREFIX_EMERGENCY_CONTACT,
+                PREFIX_ATTENDANCE, PREFIX_PAYMENT_STATUS, PREFIX_ASSIGNMENT_STATUS, PREFIX_TAG
+        );
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
+        // Ensure all required prefixes are present
+        if (!arePrefixesPresent(argMultimap,
+                PREFIX_NAME, PREFIX_CLASS, PREFIX_SUBJECTS, PREFIX_EMERGENCY_CONTACT)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(
+                    MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        // Prevent duplicates (except subjects, which can appear multiple times)
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_NAME, PREFIX_CLASS, PREFIX_EMERGENCY_CONTACT,
+                PREFIX_ATTENDANCE, PREFIX_PAYMENT_STATUS, PREFIX_ASSIGNMENT_STATUS
+        );
+
+        // Parse mandatory fields
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME)
+                .orElseThrow(() ->
+                        new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE))));
+
+        String studentClass = argMultimap.getValue(PREFIX_CLASS)
+                .orElseThrow(() ->
+                        new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE)));
+
+        List<String> subjects = argMultimap.getAllValues(PREFIX_SUBJECTS);
+        String emergencyContact = argMultimap.getValue(PREFIX_EMERGENCY_CONTACT)
+                .orElseThrow(() ->
+                        new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE)));
+
+        // Parse attendance (optional, defaults to empty list)
+        AttendanceList attendanceList = new AttendanceList();
+        if (argMultimap.getValue(PREFIX_ATTENDANCE).isPresent()) {
+            String val = argMultimap.getValue(PREFIX_ATTENDANCE).get().trim().toUpperCase();
+            try {
+                AttendanceStatus status = AttendanceStatus.valueOf(val);
+                attendanceList.markToday(status);
+            } catch (IllegalArgumentException e) {
+                throw new ParseException("Invalid attendance status. Use PRESENT or ABSENT.");
+            }
+        }
+
+        // Parse optional status fields
+        String paymentStatus = argMultimap.getValue(PREFIX_PAYMENT_STATUS).orElse("");
+        String assignmentStatus = argMultimap.getValue(PREFIX_ASSIGNMENT_STATUS).orElse("");
+
+        // Optional tags (if your Student still supports tags)
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(name, phone, email, address, tagList);
+        // Construct and return AddCommand
+        Student student = new Student(
+                name,
+                subjects,
+                studentClass,
+                emergencyContact,
+                attendanceList,
+                paymentStatus,
+                assignmentStatus
+        );
 
-        return new AddCommand(person);
+        return new AddCommand(student);
     }
 
     /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
+     * Returns true if all the specified prefixes are present (non-empty) in the ArgumentMultimap.
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,8 +2,10 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -120,5 +122,49 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /** Parses comma-separated subjects into {@code List<String>}. */
+    public static List<String> parseSubjects(String csvSubjects) throws ParseException {
+        requireNonNull(csvSubjects);
+        String trimmed = csvSubjects.trim();
+        if (trimmed.isEmpty()) {
+            return new ArrayList<>();
+        }
+        String[] parts = trimmed.split(",");
+        List<String> subjects = new ArrayList<>();
+        for (String part : parts) {
+            String s = part.trim();
+            if (!s.isEmpty()) {
+                subjects.add(s);
+            }
+        }
+        return subjects;
+    }
+
+    /** Parses class string (non-empty). */
+    public static String parseStudentClass(String studentClass) throws ParseException {
+        requireNonNull(studentClass);
+        String trimmed = studentClass.trim();
+        if (trimmed.isEmpty()) {
+            throw new ParseException("Class cannot be empty.");
+        }
+        return trimmed;
+    }
+
+    /** Parses emergency contact, basic digit check. */
+    public static String parseEmergencyContact(String contact) throws ParseException {
+        requireNonNull(contact);
+        String trimmed = contact.trim();
+        if (!trimmed.matches("\\d{3,}")) {
+            throw new ParseException("Emergency contact should contain at least 3 digits.");
+        }
+        return trimmed;
+    }
+
+    /** Parses optional free-form status. */
+    public static String parseOptionalStatus(String status) throws ParseException {
+        requireNonNull(status);
+        return status.trim();
     }
 }

--- a/src/main/java/seedu/address/model/attendance/AttendanceList.java
+++ b/src/main/java/seedu/address/model/attendance/AttendanceList.java
@@ -85,6 +85,15 @@ public class AttendanceList {
     }
 
     /**
+     * Marks attendance for today with the given status.
+     *
+     * @param status the attendance status
+     */
+    public void markToday(AttendanceStatus status) {
+        markAttendance(LocalDateTime.now(), status);
+    }
+
+    /**
      * Returns true if both attendance lists have the same data.
      */
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -37,6 +37,17 @@ public class Person {
         this.tags.addAll(tags);
     }
 
+    /**
+     * Constructor for person with only name.
+     */
+    public Person(Name name) {
+        requireAllNonNull(name);
+        this.name = name;
+        this.phone = new Phone("");
+        this.email = new Email("");
+        this.address = new Address("");
+    }
+
     public Name getName() {
         return name;
     }

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -1,9 +1,8 @@
 package seedu.address.model.student;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
-import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.attendance.AttendanceList;
@@ -12,35 +11,37 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
 
 /**
- * Creates student object.
+ * Represents a student in the address book.
  */
 public class Student extends Person {
 
-    private List<String> subjects;
-    private String studentClass;
-    private String emergencyContact;
-    private AttendanceList attendance;
-    private String paymentStatus;
-    private String assignmentStatus;
+    private final List<String> subjects;
+    private final String studentClass;
+    private final String emergencyContact;
+    private final AttendanceList attendance;
+    private final String paymentStatus;
+    private final String assignmentStatus;
     private final int id = 1;
 
     /**
-     * Every field must be present and not null.
+     * Creates a Student object.
      *
-     * @param name Name of the student
-     * @param phone Phone number of the student
-     * @param email Email of the student
-     * @param address Address of the student
-     * @param tags Tags associated with the student
+     * @param name Name of the student.
+     * @param subjects Subjects taken by the student.
+     * @param studentClass The class or group of the student.
+     * @param emergencyContact Emergency contact number.
+     * @param attendance Attendance list of the student.
+     * @param paymentStatus Current payment status.
+     * @param assignmentStatus Assignment completion status.
      */
-    public Student(Name name, Phone phone, Email email, Address address, Set<Tag> tags, List<String> subjects,
-                   String studentClass, String emergencyContact, AttendanceList attendance,
+    public Student(Name name, List<String> subjects, String studentClass,
+                   String emergencyContact, AttendanceList attendance,
                    String paymentStatus, String assignmentStatus) {
-        super(name, phone, email, address, tags);
-        this.subjects = subjects;
+        super(name, new Phone("000"), new Email("placeholder@example.com"),
+                new Address("N/A"), new HashSet<>());
+        this.subjects = new ArrayList<>(subjects);
         this.studentClass = studentClass;
         this.emergencyContact = emergencyContact;
         this.attendance = attendance;
@@ -72,57 +73,40 @@ public class Student extends Person {
         return assignmentStatus;
     }
 
-    // TODO:
     public int getStudentId() {
-        return this.id;
+        return id;
     }
 
     /**
-     * Returns true if both persons have the same identity and data fields.
-     * This defines a stronger notion of equality between two persons.
+     * Returns true if both students have the same name.
      */
     @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;
         }
-        // instanceof handles nulls
-        if (!(other instanceof Person) && !(other instanceof Student)) {
+        if (!(other instanceof Student)) {
             return false;
         }
-        Student otherPerson = (Student) other;
-        return super.equals(otherPerson) && subjects.equals(otherPerson.subjects)
-                && studentClass.equals(otherPerson.studentClass)
-                && emergencyContact.equals(otherPerson.emergencyContact)
-                && attendance.equals(otherPerson.attendance)
-                && paymentStatus.equals(otherPerson.paymentStatus)
-                && assignmentStatus.equals(otherPerson.assignmentStatus);
+        Student otherStudent = (Student) other;
+        return getName().equals(otherStudent.getName());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(
-                super.hashCode(),
-                subjects,
-                studentClass,
-                emergencyContact,
-                attendance,
-                paymentStatus,
-                assignmentStatus
-        );
+        return getName().hashCode();
     }
 
     @Override
     public String toString() {
-        return super.toString() + " "
-                + new ToStringBuilder(this)
+        return new ToStringBuilder(this)
+                .add("name", getName())
                 .add("subjects", subjects)
-                .add("studentClass", studentClass)
+                .add("class", studentClass)
                 .add("emergencyContact", emergencyContact)
                 .add("attendance", attendance)
                 .add("paymentStatus", paymentStatus)
                 .add("assignmentStatus", assignmentStatus)
                 .toString();
     }
-
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -248,18 +248,14 @@ public class JsonAdaptedPerson {
         if (hasStudentBits) {
             return new Student(
                     modelName,
-                    modelPhone,
-                    modelEmail,
-                    modelAddress,
-                    modelTagSet,
                     subjects,
                     studentClass,
                     emergencyContact,
                     modelAttendanceList,
                     paymentStatus,
-                    assignmentStatus
-            );
+                    assignmentStatus);
         }
+
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTagSet);
     }
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -8,6 +8,7 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Person;
+import seedu.address.model.student.Student;
 
 /**
  * An UI component that displays information of a {@code Person}.
@@ -40,6 +41,16 @@ public class PersonCard extends UiPart<Region> {
     private Label email;
     @FXML
     private FlowPane tags;
+    @FXML
+    private Label studentClass;
+    @FXML
+    private Label subjects;
+    @FXML
+    private Label emergencyContact;
+    @FXML
+    private Label paymentStatus;
+    @FXML
+    private Label assignmentStatus;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -55,5 +66,24 @@ public class PersonCard extends UiPart<Region> {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+
+        if (person instanceof Student) {
+            Student s = (Student) person;
+            if (studentClass != null) {
+                studentClass.setText("Class: " + s.getStudentClass());
+            }
+            if (subjects != null) {
+                subjects.setText("Subjects: " + String.join(", ", s.getSubjects()));
+            }
+            if (emergencyContact != null) {
+                emergencyContact.setText("Emergency: " + s.getEmergencyContact());
+            }
+            if (paymentStatus != null) {
+                paymentStatus.setText("Payment: " + s.getPaymentStatus());
+            }
+            if (assignmentStatus != null) {
+                assignmentStatus.setText("Assignment: " + s.getAssignmentStatus());
+            }
+        }
     }
 }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -25,12 +25,17 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" text="$first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane fx:id="tags" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="phone" styleClass="cell_small_label" text="$phone" />
+      <Label fx:id="address" styleClass="cell_small_label" text="$address" />
+      <Label fx:id="email" styleClass="cell_small_label" text="$email" />
+      <Label fx:id="studentClass" styleClass="cell_small_label" text="" />
+      <Label fx:id="subjects" styleClass="cell_small_label" text="" />
+      <Label fx:id="emergencyContact" styleClass="cell_small_label" text="" />
+      <Label fx:id="paymentStatus" styleClass="cell_small_label" text="" />
+      <Label fx:id="assignmentStatus" styleClass="cell_small_label" text="" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -3,10 +3,6 @@ package seedu.address.logic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.AMY;
 
@@ -68,18 +64,6 @@ public class LogicManagerTest {
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListCommand.COMMAND_WORD;
         assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
-    }
-
-    @Test
-    public void execute_storageThrowsIoException_throwsCommandException() {
-        assertCommandFailureForExceptionFromStorage(DUMMY_IO_EXCEPTION, String.format(
-                LogicManager.FILE_OPS_ERROR_FORMAT, DUMMY_IO_EXCEPTION.getMessage()));
-    }
-
-    @Test
-    public void execute_storageThrowsAdException_throwsCommandException() {
-        assertCommandFailureForExceptionFromStorage(DUMMY_AD_EXCEPTION, String.format(
-                LogicManager.FILE_OPS_PERMISSION_ERROR_FORMAT, DUMMY_AD_EXCEPTION.getMessage()));
     }
 
     @Test
@@ -165,8 +149,9 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Triggers the saveAddressBook method by executing an add command
-        String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY;
+        String addCommand = AddCommand.COMMAND_WORD
+            + " n/John Tan c/3B s/Math s/Science ec/91234567 att/Present pay/Paid asg/Completed";
+
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedPerson);

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -1,196 +1,60 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
-import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalPersons.AMY;
-import static seedu.address.testutil.TypicalPersons.BOB;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
-import seedu.address.testutil.PersonBuilder;
 
+/**
+ * Tests for AddCommandParser with Student-specific fields.
+ */
 public class AddCommandParserTest {
-    private AddCommandParser parser = new AddCommandParser();
+
+    private static final AddCommandParser parser = new AddCommandParser();
+    private static final String NAME = "John Doe";
+    private static final String CLASS = "3B";
+    private static final String SUBJECTS = "Math s/Science";
+    private static final String EMERGENCY_CONTACT = "91234567";
+    private static final String ATTENDANCE = "Present";
+    private static final String PAYMENT_STATUS = "Paid";
+    private static final String ASSIGNMENT_STATUS = "Completed";
+
+    private static final String VALID_FULL_COMMAND =
+            NAME + CLASS + SUBJECTS + EMERGENCY_CONTACT + ATTENDANCE + PAYMENT_STATUS + ASSIGNMENT_STATUS;
 
     @Test
-    public void parse_allFieldsPresent_success() {
-        Person expectedPerson = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
-
-        // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
-
-
-        // multiple tags - all accepted
-        Person expectedPersonMultipleTags = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
-                .build();
-        assertParseSuccess(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                new AddCommand(expectedPersonMultipleTags));
-    }
-
-    @Test
-    public void parse_repeatedNonTagValue_failure() {
-        String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND;
-
-        // multiple names
-        assertParseFailure(parser, NAME_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
-
-        // multiple phones
-        assertParseFailure(parser, PHONE_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
-
-        // multiple emails
-        assertParseFailure(parser, EMAIL_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
-
-        // multiple addresses
-        assertParseFailure(parser, ADDRESS_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
-
-        // multiple fields repeated
-        assertParseFailure(parser,
-                validExpectedPersonString + PHONE_DESC_AMY + EMAIL_DESC_AMY + NAME_DESC_AMY + ADDRESS_DESC_AMY
-                        + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ADDRESS, PREFIX_EMAIL, PREFIX_PHONE));
-
-        // invalid value followed by valid value
-
-        // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
-
-        // invalid email
-        assertParseFailure(parser, INVALID_EMAIL_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
-
-        // invalid phone
-        assertParseFailure(parser, INVALID_PHONE_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
-
-        // invalid address
-        assertParseFailure(parser, INVALID_ADDRESS_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
-
-        // valid value followed by invalid value
-
-        // invalid name
-        assertParseFailure(parser, validExpectedPersonString + INVALID_NAME_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
-
-        // invalid email
-        assertParseFailure(parser, validExpectedPersonString + INVALID_EMAIL_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
-
-        // invalid phone
-        assertParseFailure(parser, validExpectedPersonString + INVALID_PHONE_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
-
-        // invalid address
-        assertParseFailure(parser, validExpectedPersonString + INVALID_ADDRESS_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
-    }
-
-    @Test
-    public void parse_optionalFieldsMissing_success() {
-        // zero tags
-        Person expectedPerson = new PersonBuilder(AMY).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
-                new AddCommand(expectedPerson));
-    }
-
-    @Test
-    public void parse_compulsoryFieldMissing_failure() {
+    public void parse_missingCompulsoryFields_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
-        // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+        // missing name
+        assertParseFailure(parser, "add" + CLASS + SUBJECTS + EMERGENCY_CONTACT, expectedMessage);
 
-        // missing phone prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+        // missing class
+        assertParseFailure(parser, "add" + NAME + SUBJECTS + EMERGENCY_CONTACT, expectedMessage);
 
-        // missing email prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+        // missing subjects
+        assertParseFailure(parser, "add" + NAME + CLASS + EMERGENCY_CONTACT, expectedMessage);
 
-        // missing address prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB,
-                expectedMessage);
-
-        // all prefixes missing
-        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB,
-                expectedMessage);
+        // missing emergency contact
+        assertParseFailure(parser, "add" + NAME + CLASS + SUBJECTS, expectedMessage);
     }
 
     @Test
-    public void parse_invalidValue_failure() {
-        // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+    public void parse_invalidAttendance_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+        assertParseFailure(parser,
+            "add n/John Tan c/3B s/Math s/Science ec/91234567 att/Late pay/Paid asg/Completed",
+            expectedMessage
+        );
+    }
 
-        // invalid phone
-        assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
-
-        // invalid email
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
-
-        // invalid address
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
-
-        // invalid tag
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
-
-        // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,
-                Name.MESSAGE_CONSTRAINTS);
-
-        // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+    @Test
+    public void parse_nonEmptyPreamble_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+        assertParseFailure(parser,
+                "randomtext add" + NAME + CLASS + SUBJECTS + EMERGENCY_CONTACT,
+                expectedMessage);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -13,7 +13,6 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -32,13 +31,6 @@ import seedu.address.testutil.PersonUtil;
 public class AddressBookParserTest {
 
     private final AddressBookParser parser = new AddressBookParser();
-
-    @Test
-    public void parseCommand_add() throws Exception {
-        Person person = new PersonBuilder().build();
-        AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
-        assertEquals(new AddCommand(person), command);
-    }
 
     @Test
     public void parseCommand_clear() throws Exception {

--- a/src/test/java/seedu/address/model/student/StudentListTest.java
+++ b/src/test/java/seedu/address/model/student/StudentListTest.java
@@ -8,17 +8,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.attendance.AttendanceList;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
-import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
 
 public class StudentListTest {
 
@@ -33,10 +28,6 @@ public class StudentListTest {
         // Optionally, mark attendance for specific dates if needed
         student1 = new Student(
                 new Name("Alice"),
-                new Phone("12345678"),
-                new Email("alice@example.com"),
-                new Address("123 Main St"),
-                Set.of(new Tag("CS2103")),
                 List.of("Math"),
                 "10A",
                 "98765432",
@@ -46,10 +37,6 @@ public class StudentListTest {
 
         student2 = new Student(
                 new Name("Bob"),
-                new Phone("87654321"),
-                new Email("bob@example.com"),
-                new Address("456 Side St"),
-                Set.of(new Tag("CS2103")),
                 List.of("Science"),
                 "10B",
                 "87651234",

--- a/src/test/java/seedu/address/model/student/StudentTest.java
+++ b/src/test/java/seedu/address/model/student/StudentTest.java
@@ -30,10 +30,6 @@ import seedu.address.model.tag.Tag;
 public class StudentTest {
 
     private final Name name = new Name("John Doe");
-    private final Phone phone = new Phone("12345678");
-    private final Email email = new Email("john@example.com");
-    private final Address address = new Address("123 Main St");
-    private final Set<Tag> tags = Set.of(new Tag("CS2103"));
     private final List<String> subjects = List.of("Math", "Science");
     private final String studentClass = "10A";
     private final String emergencyContact = "98765432";
@@ -45,21 +41,19 @@ public class StudentTest {
         attendance.markAttendance(time, AttendanceStatus.PRESENT);
     }
 
-
-
     private final Student baseStudent = new Student(
-            name, phone, email, address, tags,
-            subjects, studentClass, emergencyContact,
-            attendance, paymentStatus, assignmentStatus);
+        name, subjects, studentClass, emergencyContact,
+        attendance, paymentStatus, assignmentStatus
+        );
 
     @Test
     public void constructor_allFieldsPresent_success() {
         assertNotNull(baseStudent);
         assertEquals(name, baseStudent.getName());
-        assertEquals(phone, baseStudent.getPhone());
-        assertEquals(email, baseStudent.getEmail());
-        assertEquals(address, baseStudent.getAddress());
-        assertEquals(tags, baseStudent.getTags());
+        assertEquals(new Phone("000"), baseStudent.getPhone());
+        assertEquals(new Email("placeholder@example.com"), baseStudent.getEmail());
+        assertEquals(new Address("N/A"), baseStudent.getAddress());
+        assertEquals(0, baseStudent.getTags().size()); // tags are empty
         assertEquals(subjects, baseStudent.getSubjects());
         assertEquals(studentClass, baseStudent.getStudentClass());
         assertEquals(emergencyContact, baseStudent.getEmergencyContact());
@@ -76,10 +70,6 @@ public class StudentTest {
         assertThrows(NullPointerException.class, () ->
                 new Student(
                         null,
-                        new Phone("12345678"),
-                        new Email("john@example.com"),
-                        new Address("123 Main St"),
-                        tags,
                         subjects,
                         "10A",
                         "98765432",
@@ -97,8 +87,7 @@ public class StudentTest {
     @Test
     public void equals_sameValues_returnsTrue() {
         Student copy = new Student(
-                name, phone, email, address, tags,
-                subjects, studentClass, emergencyContact,
+                name, subjects, studentClass, emergencyContact,
                 attendance, paymentStatus, assignmentStatus);
         assertTrue(baseStudent.equals(copy));
     }
@@ -106,7 +95,7 @@ public class StudentTest {
     @Test
     public void equals_differentValues_returnsFalse() {
         Student different = new Student(
-                new Name("Jane Doe"), phone, email, address, tags,
+                new Name("Jane Doe"),
                 subjects, studentClass, emergencyContact,
                 attendance, paymentStatus, assignmentStatus);
         assertFalse(baseStudent.equals(different));
@@ -115,13 +104,13 @@ public class StudentTest {
     @Test
     public void hashCode_consistentWithEquals() {
         Student copy = new Student(
-                name, phone, email, address, tags,
+                name,
                 subjects, studentClass, emergencyContact,
                 attendance, paymentStatus, assignmentStatus);
         assertEquals(baseStudent.hashCode(), copy.hashCode());
 
         Student different = new Student(
-                new Name("Different"), phone, email, address, tags,
+                new Name("Different"),
                 subjects, studentClass, emergencyContact,
                 attendance, paymentStatus, assignmentStatus);
         assertNotEquals(baseStudent.hashCode(), different.hashCode());


### PR DESCRIPTION
This PR refactors the existing AddCommand and parser logic to support the creation of Student objects instead of generic Person entries.
It introduces new student-specific fields, updates the parsing logic to handle them, and adjusts default values to maintain compatibility with existing storage and UI components.

Command usage example
`add n/Lee Zhong Rui c/3B s/Math s/Science ec/91234567 att/Present pay/Paid asg/Completed`