### PR TITLE
Fix command naming convention

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.lesson.Lesson;
  */
 public class AddLessonCommand extends Command {
 
-    public static final String COMMAND_WORD = "AddLesson";
+    public static final String COMMAND_WORD = "addlesson";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a lesson to a subject. "
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/ListLessonsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListLessonsCommand.java
@@ -15,7 +15,7 @@ import seedu.address.model.subject.Subject;
  */
 public class ListLessonsCommand extends Command {
 
-    public static final String COMMAND_WORD = "ListLessons";
+    public static final String COMMAND_WORD = "listlessons";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all lessons in a subject. "
             + "Parameters: "


### PR DESCRIPTION
Fix command naming convention for 2 commands: closes #128 
- AddLesson --> addlesson
- ListLessons --> listlessons

