### PR TITLE
Improve subject parsing & de-duplication across add and edit commands

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PAYMENT_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECTS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -53,8 +54,10 @@ public class AddCommandParser implements Parser<AddCommand> {
                 new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE)));
 
         List<String> subjects = argMultimap.getAllValues(PREFIX_SUBJECTS);
-        if (subjects.isEmpty()) {
-            throw new ParseException("At least one subject must be provided using " + PREFIX_SUBJECTS);
+        List<Subject> subjectList = new ArrayList<>();
+
+        if (!subjects.isEmpty() && (!(subjects.size() == 1) || !subjects.get(0).trim().isEmpty())) {
+            subjectList = ParserUtil.parseSubjects(subjects);
         }
 
         String emergencyContact = ParserUtil.parseEmergencyContact(
@@ -76,7 +79,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         // Construct Student (AttendanceList is created internally by Student)
         Student student = new Student(
                 name,
-                subjects.stream().map(Subject::new).toList(),
+                subjectList,
                 studentClass,
                 emergencyContact,
                 paymentStatus,

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -13,8 +13,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECTS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+//import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+//import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -23,6 +26,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
+//import seedu.address.model.subject.Subject;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -54,10 +58,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         assert index != null : "Index must be parsed";
 
-        // Reject duplicate single-occurrence prefixes early
+        // Reject duplicate single-occurrence prefixes early (subjects/tags can repeat)
         argMultimap.verifyNoDuplicatePrefixesFor(
                 PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                PREFIX_CLASS, PREFIX_SUBJECTS, PREFIX_EMERGENCY_CONTACT,
+                PREFIX_CLASS, PREFIX_EMERGENCY_CONTACT,
                 PREFIX_PAYMENT_STATUS, PREFIX_ASSIGNMENT_STATUS
         );
 
@@ -71,7 +75,14 @@ public class EditCommandParser implements Parser<EditCommand> {
         parseTags(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(descriptor::setTags);
 
         parseAndSet(argMultimap, PREFIX_CLASS, ParserUtil::parseStudentClass, descriptor::setStudentClass);
-        parseAndSet(argMultimap, PREFIX_SUBJECTS, ParserUtil::parseSubjects, descriptor::setSubjects);
+        List<String> subjects = argMultimap.getAllValues(PREFIX_SUBJECTS);
+        if (!subjects.isEmpty()) {
+            if (subjects.size() == 1 && subjects.get(0).trim().isEmpty()) {
+                descriptor.setSubjects(Collections.emptyList());
+            } else {
+                descriptor.setSubjects(ParserUtil.parseSubjects(subjects));
+            }
+        }
         parseAndSet(argMultimap, PREFIX_EMERGENCY_CONTACT, ParserUtil::parseEmergencyContact,
                 descriptor::setEmergencyContact);
         parseAndSet(argMultimap, PREFIX_PAYMENT_STATUS, ParserUtil::parsePaymentStatus, descriptor::setPaymentStatus);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -201,20 +201,21 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseSubjects_emptyString_returnsEmptyList() throws Exception {
-        assertTrue(ParserUtil.parseSubjects("   ").isEmpty());
+    public void parseSubjects_emptyString_throwsParserException() throws Exception {
+        assertThrows(ParseException.class,
+            "Subject names should not be empty", () -> ParserUtil.parseSubjects(Arrays.asList("  ")));
     }
 
     @Test
     public void parseSubjects_validCommaSeparated_returnsList() throws Exception {
         assertEquals(Arrays.asList(new Subject("Math"), new Subject("Science")),
-                ParserUtil.parseSubjects("Math, Science"));
+                ParserUtil.parseSubjects(Arrays.asList("Math, Science")));
     }
 
     @Test
     public void parseSubjects_withExtraSpaces_returnsTrimmedList() throws Exception {
-        assertEquals(Arrays.asList(new Subject("Math"), new Subject("English")),
-                ParserUtil.parseSubjects("  Math ,  English  "));
+        assertEquals(Arrays.asList(new Subject("Math"), new Subject("Science")),
+                ParserUtil.parseSubjects(Arrays.asList("   Math  ,  Science  ")));
     }
 
     @Test


### PR DESCRIPTION
Fixes #223, fixes #230, fixes #270, fixes #275, fixes #277, fixes #286

## Summary

This PR standardizes how subjects are parsed and validated for both add and edit commands. It accepts repeated prefixes and CSV within a single prefix, trims input, rejects empties, and prevents case-insensitive duplicates while preserving the first spelling.

## What changed
- ParserUtil
- `parseSubjects(Collection<String>)`:
  - Accepts both s/Math s/Science and s/Math, Science (and mixed).
  - Splits on commas, trim()s pieces, ignores empty tokens.
  - Performs case-insensitive de-duplication using toLowerCase(Locale.ROOT) while preserving the first spelling added (e.g., Math + MAth → keep Math).
  - Throws ParseException with message Subject names should not be empty for whitespace-only or empty tokens.
- `AddCommandParser` / `EditCommandParser`
  - Use getAllValues(PREFIX_SUBJECTS) to collect all s/ values.
  - Delegate to ParserUtil.parseSubjects(...) for consistent behavior.
  - (Unchanged) Other single-value prefixes still use duplicate-prefix checks.

## Rationale
- Previous behavior created a single subject "Math, Science" instead of two.
- Duplicate subjects could slip through (Math vs MAth).
- Inconsistent handling between add and edit.

## Developer notes
- Case handling: We use Locale.ROOT for deterministic lower-casing (avoids locale pitfalls like Turkish I/ı).
- Original casing preserved: Stored Subject uses the first encountered spelling.
- Order preserved: Subjects appear in the order first provided.

## Examples (now supported)
```
add n/Ada Lovelace c/3A s/Math s/Science ec/91234567
add n/Alan Turing c/3B s/Math, Science ec/98765432
edit 1 s/Math, Science s/English
edit 2 s/MATH s/MAth s/Math //(results in a single "MATH" or first spelling provided)
```
