### PR TITLE
Prevent adding/editing empty subjects

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -118,7 +118,8 @@ public class EditCommand extends Command {
     }
 
     /** Creates and returns a {@code Person} edited with {@code editPersonDescriptor}. */
-    private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
+    private static Person createEditedPerson(Person personToEdit,
+        EditPersonDescriptor editPersonDescriptor) throws CommandException {
         assert personToEdit != null : "personToEdit must not be null";
 
         Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
@@ -145,7 +146,9 @@ public class EditCommand extends Command {
                 updatedEmergencyContact = editPersonDescriptor.getEmergencyContact().orElse(s.getEmergencyContact());
                 updatedPaymentStatus = editPersonDescriptor.getPaymentStatus().orElse(s.getPaymentStatus());
                 updatedAssignmentStatus = editPersonDescriptor.getAssignmentStatus().orElse(s.getAssignmentStatus());
-
+                if (updatedSubjects.isEmpty()) {
+                    throw new CommandException(Subject.MESSAGE_CONSTRAINTS);
+                }
                 Student edited = new Student(
                         updatedName,
                         updatedSubjects,
@@ -165,7 +168,9 @@ public class EditCommand extends Command {
                 updatedEmergencyContact = editPersonDescriptor.getEmergencyContact().orElse("");
                 updatedPaymentStatus = editPersonDescriptor.getPaymentStatus().orElse("");
                 updatedAssignmentStatus = editPersonDescriptor.getAssignmentStatus().orElse("");
-
+                if (updatedSubjects.isEmpty()) {
+                    throw new CommandException(Subject.MESSAGE_CONSTRAINTS);
+                }
                 return new Student(
                         updatedName,
                         updatedSubjects,

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PAYMENT_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECTS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -54,10 +53,13 @@ public class AddCommandParser implements Parser<AddCommand> {
                 new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE)));
 
         List<String> subjects = argMultimap.getAllValues(PREFIX_SUBJECTS);
-        List<Subject> subjectList = new ArrayList<>();
-
-        if (!subjects.isEmpty() && (!(subjects.size() == 1) || !subjects.get(0).trim().isEmpty())) {
-            subjectList = ParserUtil.parseSubjects(subjects);
+        List<Subject> subjectList;
+        if (!subjects.isEmpty() && subjects.size() == 1 && subjects.get(0).trim().isEmpty()) {
+            throw new ParseException(Subject.MESSAGE_CONSTRAINTS);
+        }
+        subjectList = ParserUtil.parseSubjects(subjects);
+        if (subjectList.isEmpty()) {
+            throw new ParseException(Subject.MESSAGE_CONSTRAINTS);
         }
 
         String emergencyContact = ParserUtil.parseEmergencyContact(

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -24,6 +24,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.subject.Subject;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -74,10 +75,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         List<String> subjects = argMultimap.getAllValues(PREFIX_SUBJECTS);
         if (!subjects.isEmpty()) {
             if (subjects.size() == 1 && subjects.get(0).trim().isEmpty()) {
-                descriptor.setSubjects(Collections.emptyList());
-            } else {
-                descriptor.setSubjects(ParserUtil.parseSubjects(subjects));
+                throw new ParseException(Subject.MESSAGE_CONSTRAINTS);
             }
+            descriptor.setSubjects(ParserUtil.parseSubjects(subjects));
         }
         parseAndSet(argMultimap, PREFIX_EMERGENCY_CONTACT, ParserUtil::parseEmergencyContact,
                 descriptor::setEmergencyContact);


### PR DESCRIPTION
Fixes #274

This PR blocks users from creating or editing a student with empty subject entries. Attempts to add s/    (whitespace) or equivalent now surface a clear error to the user instead of silently doing nothing or crashing later.

## Summary
- When a subject field is empty/whitespace, the command fails with an error message (e.g., “Subject names should not be empty”).
- Valid inputs continue to work, including:
- Repeated prefixes: s/Math s/Science
- CSV form: s/Math, Science
- Mixed: s/Math, Science s/English
 
## Amendments
- ParserUtil.parseSubjects(…): trims, validates, and throws ParseException on empty/invalid tokens; also de-dups case-insensitively while preserving first spelling.
- EditCommandParser / AddCommandParser: always route subject input through ParserUtil.parseSubjects(...); removed the branch that produced an empty subject list.
- (Optional guard, if included) Added a defensive check to prevent constructing a Student with zero subjects.

## Rationale

Previously, an “empty reset” path allowed subjects = [], leading to runtime assertions instead of a user-visible parse error. Centralizing validation in ParserUtil and removing the empty-reset path ensures errors are caught early and shown to the user.